### PR TITLE
DENG-215: pin + 7-day dependency cooldown (.npmrc)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+save-prefix=
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/fenderdigital/icon-library#readme",
   "devDependencies": {
-    "copyfiles": "^1.2.0",
-    "tachyons-cli": "^1.3.2"
+    "copyfiles": "1.2.0",
+    "tachyons-cli": "1.3.2"
   }
 }


### PR DESCRIPTION
## DENG-215 — dependency supply-chain hardening (Tier 1: config)

This PR adds `.npmrc` to enforce dependency policy at install time.

```ini
save-exact=true     # pin: future `npm install <pkg>` writes exact versions
save-prefix=        # no range prefix
min-release-age=7   # 7-day cooldown: only versions published >7 days ago resolve
```

**Requires npm ≥ 11** (Node 24 ships it) for `min-release-age` to take effect. CI/dev on older npm will ignore the cooldown line (safe no-op).

- Cooldown applies to *new/updated* deps; `npm ci` from the committed lockfile is unaffected.
- A follow-up PR will pin existing floating ranges (2 found) and regenerate the lockfile.

Ref: https://fenderdigital.atlassian.net/browse/DENG-215